### PR TITLE
chore: use public package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git://github.com/descope/passport-descope.git"
+    "url": "git+https://github.com/descope/passport-descope.git"
   },
   "engines": {
     "node": ">= 18.0.0"
@@ -30,7 +30,7 @@
   },
   "author": "Descope",
   "bugs": {
-    "url": "git://github.com/descope/passport-descope/issues"
+    "url": "https://github.com/descope/passport-descope/issues"
   },
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
## Summary

- Update `package.json#repository.url` from the unauthenticated `git://` URL to the public HTTPS form.
- Update `package.json#bugs.url` to the public GitHub issues HTTPS URL.

## Validation

- Checked the current npm metadata for `passport-descope@1.0.0`.
- Parsed `package.json` and asserted the repository and bugs URLs use public HTTPS metadata.
- `git diff --check`
- `git ls-remote https://github.com/descope/passport-descope.git HEAD`
